### PR TITLE
Fixed an URI.parse bug and improved Windows support

### DIFF
--- a/helper/download-helper.rb
+++ b/helper/download-helper.rb
@@ -1,42 +1,57 @@
 class DownloadHelper
 #usually not called directly
-def self.fetch_file(uri)
+  def self.fetch_file(uri)
 
-begin
-	require "progressbar" #http://github.com/nex3/ruby-progressbar
-rescue LoadError
-	puts "ERROR: You don't seem to have curl or wget on your system. In this case you'll need to install the 'progressbar' gem."
-	exit
-end
-  progress_bar = nil 
-  open(uri, :proxy => nil,
-    :content_length_proc => lambda { |length|
-      if length && 0 < length
-        progress_bar = ProgressBar.new(uri.to_s, length)
-      end 
-    },
-    :progress_proc => lambda { |progress|
-      progress_bar.set(progress) if progress_bar
-    }) {|file| return file.read}        
-end
-
-#simple helper that will save a file from the web and save it with a progress bar
-def self.save_file(file_uri, file_name)
-  unescaped_uri = CGI::unescape(file_uri)
-  result = false
-  if `which wget`.include?("wget")
-	  puts "using wget"
-  	result = system("wget \"#{unescaped_uri}\" -O #{file_name}")
-  elsif `which curl`.include?("curl")
-    puts "using curl"  
-    #-L means: follow redirects, We set an agent because Vimeo seems to want one
-  	result = system("curl -A 'Mozilla/2.02 (OS/2; U)' -L \"#{unescaped_uri}\" -o #{file_name}")
-  else
-    open(file_name, 'wb') { |file|   	
-      file.write(fetch_file(unescaped_uri)); puts
-    }
-    result = true
+  begin
+  	require "progressbar" #http://github.com/nex3/ruby-progressbar
+  rescue LoadError
+  	puts "ERROR: You don't seem to have curl or wget on your system. In this case you'll need to install the 'progressbar' gem."
+  	exit
   end
-  result
-end
+    progress_bar = nil 
+    open(uri, :proxy => nil,
+      :content_length_proc => lambda { |length|
+        if length && 0 < length
+          progress_bar = ProgressBar.new(uri.to_s, length)
+        end 
+      },
+      :progress_proc => lambda { |progress|
+        progress_bar.set(progress) if progress_bar
+      }) {|file| return file.read}        
+  end
+  
+  #simple helper that will save a file from the web and save it with a progress bar
+  def self.save_file(file_uri, file_name)
+    unescaped_uri = CGI::unescape(file_uri)
+    result = false
+    windows = ENV['OS'] =~ /windows/i
+    if os_has?("wget", windows)
+      puts "using wget"
+      result = system("wget \"#{unescaped_uri}\" -O #{file_name}")
+    elsif os_has?("curl", windows)
+      puts "using curl"
+      #-L means: follow redirects, We set an agent because Vimeo seems to want one
+    	result = system("curl -A 'Mozilla/2.02 (OS/2; U)' -L \"#{unescaped_uri}\" -o #{file_name}")
+    else
+      open(file_name, 'wb') { |file|   	      
+        file.write(fetch_file(unescaped_uri)); puts
+      }
+      result = true
+    end         
+    result
+  end
+  
+  #checks to see whether the os has a certain utility like wget or curl
+  def self.os_has?(utility, windows)
+    unless windows # if os is something else than Windows
+      return `which #{utility}`.include?(utility)
+    else
+      begin 
+        `#{utility}` #if running the command does not thow an error, Windows has it
+        return true
+      rescue Errno::ENOENT
+        return false
+      end
+    end
+  end
 end

--- a/plugins/youtube.rb
+++ b/plugins/youtube.rb
@@ -129,7 +129,9 @@ class Youtube < PluginBase
 		puts "[YOUTUBE] formats available: #{available_formats.inspect} (downloading format #{selected_format} -> #{format_ext[selected_format][:name]})"
 
 		#video_info_hash.keys.sort.each{|key| puts "#{key} : #{video_info_hash[key]}" }
-    	download_url = video_info_hash["url_encoded_fmt_stream_map"][selected_format]
+    download_url = video_info_hash["url_encoded_fmt_stream_map"][selected_format]
+    #if download url ends with a ';' followed by a codec string remove that part because stops URI.parse from working
+    download_url = $1 if download_url =~ /(.*?);\scodecs=/
 		file_name = title.delete("\"'").gsub(/[^0-9A-Za-z]/, '_') + "." + format_ext[selected_format][:extension]
 		puts "downloading to " + file_name
 		{:url => download_url, :name => file_name}


### PR DESCRIPTION
There was a bug in the youtube plugin where the download url that was returned looked something like this:

http://o-o.preferred.arn06s03.v5.lscache3.c.youtube.com/videoplayback?sparams=id,expire,ip,ipbits,itag,source,ratebypass,cp&fexp=907611,905241,906424&itag=37&ip=79.0.0.0&signature=9E058AEA1ACDA5B5E0075543BE55045ADA92A83C.22F3896EFB43909B0A2FF29D750D2AC9D4421730&sver=3&ratebypass=yes&source=youtube&expire=1321041600&key=yt1&ipbits=8&cp=U0hRRlBPT19FSkNOMV9ISVNHOnpqTVYtSnRIN2pF&id=a34c74229a7db4f5&quality=hd1080&fallback_host=tc.v5.cache3.c.youtube.com&type=video/mp4; codecs="avc1.64001F, mp4a.40.2"&itag=37

Only trying to parse this string with URI.parse (when the client is not using wget or curl) gives an error because of this part: "; codecs="avc1.64001F, mp4a.40.2"&itag=37"

This information is not used after the itag value is parsed, so I removed it from the returned download_url string. Now it can be parsed by URI.parse and downloading a youtube video using open-uri works.

The second thing I did was to improve on the Windows support. The 'which' command that is used to check whether the user has wget and curl is not a Windows command and running that code on a standard Windows install (i.e. without Cygwin) will give you an error. I extracted that code to a helper method that works in Windows too.
