### PR TITLE
Changed test a little to make it run on Windows and made the test code more dry

### DIFF
--- a/spec/url_extraction_spec.rb
+++ b/spec/url_extraction_spec.rb
@@ -15,60 +15,47 @@ class TestURLExtraction < MiniTest::Unit::TestCase
   def curl_code_grabber(url, user_agent = "Wget/1.8.1")
     `curl --silent -I -L -A "Wget/1.8.1" #{url} | grep "HTTP/"`.to_s.split("\n").last.split(" ")[1].to_i
   end
-
+    
   def test_youtube
-   result = `bin/viddl-rb http://www.youtube.com/watch?v=CFw6s0TN3hY --url-only`
-   url_output = result.split("\n").last
-   http_response_code = http_code_grabber(url_output)
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http://')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://www.youtube.com/watch?v=CFw6s0TN3hY --url-only`
+    can_download_test(result)
   end
-
+  
   def test_veoh
-   result = `bin/viddl-rb http://www.veoh.com/watch/v23858585TPfM8M8z --url-only`
-   url_output = result.split("\n").last
-   http_response_code = http_code_grabber(url_output, {:method => :get})
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http://')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://www.veoh.com/watch/v23858585TPfM8M8z --url-only`
+    can_download_test(result) { |url_output| http_code_grabber(url_output, {:method => :get}) }
   end
 
   def test_megavideo
-   result = `bin/viddl-rb http://www.megavideo.com/?v=U0YPI0SO --url-only`
-   url_output = result.split("\n").last
-   http_response_code = http_code_grabber(url_output)
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http://')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://www.megavideo.com/?v=U0YPI0SO --url-only`
+    can_download_test(result)
   end
-
+  
   def test_vimeo
-   result = `bin/viddl-rb http://vimeo.com/31744552 --url-only`
-   url_output = result.split("\n").last
-   #http_response_code = http_code_grabber(url_output)
-   http_response_code = curl_code_grabber(url_output)
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http://')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://vimeo.com/31744552 --url-only`
+    can_download_test(result)
   end
 
   def test_blip_tv
-   result = `bin/viddl-rb http://blip.tv/red-vs-blue/red-vs-blue-episode-11-5526271 --url-only`
-   url_output = result.split("\n").last
-   http_response_code = http_code_grabber(url_output)  
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http://')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://blip.tv/red-vs-blue/red-vs-blue-episode-11-5526271 --url-only`
+    can_download_test(result)
   end
 
-
   def test_metacafe  
-   result = `bin/viddl-rb http://www.metacafe.com/watch/7731483/video_preview_final_fantasy_xiii_2/ --url-only`
-   url_output = result.split("\n").last
-   http_response_code = http_code_grabber(CGI::unescape(url_output))
-   #Check that we COULD download the file
-   assert_includes(url_output, 'http')
-   assert_equal(200, http_response_code)
+    result = `ruby bin/viddl-rb http://www.metacafe.com/watch/7731483/video_preview_final_fantasy_xiii_2/ --url-only`
+    can_download_test(result) { |url_output| http_code_grabber(CGI::unescape(url_output)) }
+  end
+  
+  private
+  
+  def can_download_test(result, &grabber)
+    code_grabber = grabber || proc { |url_output| http_code_grabber(url_output) }
+    result = `ruby bin/viddl-rb http://www.youtube.com/watch?v=CFw6s0TN3hY --url-only`
+    url_output = result.split("\n").last
+    http_response_code = code_grabber.call(url_output)
+    
+    #Check that we COULD download the file
+    assert_includes(url_output, 'http://')
+    assert_equal(200, http_response_code)
   end
 end


### PR DESCRIPTION
The test's wouldn't run on Windows because you have to be explicit and use the ruby command when running bin/viddl-rb like this for example: `ruby bin/viddl-rb http://www.youtube.com/watch?v=CFw6s0TN3hY --url-only`

I changed all the tests to use the ruby command explicitly. I don't think this change will affect Linux/OSX but if it does then we could make an OS check in the test file and change it depending on the OS.

The second thing I did was to remove some of the duplication in the tests and extract it to a helper method.
