### PR TITLE
Regex filtering for Youtube user/playlist downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ Download a video and extract the audio:
 
 In both cases we'll name the output file according to the video title.
 
-Download all videos on a Youtube playlist:
+Download all videos on a Youtube playlist:  
     viddl-rb http://www.youtube.com/playlist?list=PL7E8DA0A515924126
 
-Download all videos from a Youtube user:
+Download all videos from a Youtube user:  
     viddl-rb http://www.youtube.com/user/tedtalksdirector
+
+Filter videos to download from a Youtube user/playlist:  
+    viddl-rb http://www.youtube.com/user/tedtalksdirector --filter=internet/i
+
+The --filter argument accepts a regular expression and will only download  
+videos whose titles match the regex. The /i option does a case-insensitive search.
 
 __Requirements:__
 


### PR DESCRIPTION
Hi again here is another feature I thought was useful. By passing along the --filter=regex option you can now download only the videos in a feed that that have titles that match the regex.

So to download all TED talks with "Internet" in the title you can type:

viddl-rb http://www.youtube.com/user/tedtalksdirector --filter=Internet

and to make the search case-insensitive do this:

viddl-rb http://www.youtube.com/user/tedtalksdirector --filter=Internet/i
