### PR TITLE
Use ViddlRb module as namespace

### DIFF
--- a/bin/helper/downloader.rb
+++ b/bin/helper/downloader.rb
@@ -20,6 +20,6 @@ class Downloader
 
   # TODO save_dir is not used yet
   def save_file(url, name, save_dir)
-    DownloadHelper.save_file(url, name, save_dir)
+    ViddlRb::DownloadHelper.save_file(url, name, save_dir)
   end
 end

--- a/bin/helper/driver.rb
+++ b/bin/helper/driver.rb
@@ -27,7 +27,7 @@ class Driver
   #finds the right plugins and returns the download queue.
   def get_download_queue
     url = @params[:url]
-    plugin = PluginBase.registered_plugins.find { |p| p.matches_provider?(url) }
+    plugin = ViddlRb::PluginBase.registered_plugins.find { |p| p.matches_provider?(url) }
     raise "ERROR: No plugin seems to feel responsible for this URL." unless plugin
     puts "Using plugin: #{plugin}"
 
@@ -35,7 +35,7 @@ class Driver
       #we'll end up with an array of hashes with they keys :url and :name 
       plugin.get_urls_and_filenames(url, @params)
       
-    rescue PluginBase::CouldNotDownloadVideoError => e
+    rescue ViddlRb::PluginBase::CouldNotDownloadVideoError => e
       raise "ERROR: The video could not be downloaded.\n" +
             "Reason: #{e.message}"
     rescue StandardError => e

--- a/bin/viddl-rb
+++ b/bin/viddl-rb
@@ -23,8 +23,8 @@ begin
   params = ParameterParser.parse_app_parameters
 
   puts "Loading Plugins"
-  UtilityHelper.load_plugins
-  "Plugins loaded: #{PluginBase.registered_plugins.inspect}"
+  ViddlRb::UtilityHelper.load_plugins
+  "Plugins loaded: #{ViddlRb::PluginBase.registered_plugins.inspect}"
 
   puts "Will try to extract audio: #{params[:extract_audio] == true}."
   puts "Analyzing URL: #{params[:url]}"
@@ -36,3 +36,4 @@ rescue StandardError => e
   puts "#{e.message}"
   exit(1)
 end
+

--- a/helper/audio-helper.rb
+++ b/helper/audio-helper.rb
@@ -1,45 +1,49 @@
+module ViddlRb
 
-# This class is responsible for extracting audio from video files using ffmpeg.
-class AudioHelper
+  # This class is responsible for extracting audio from video files using ffmpeg.
+  class AudioHelper
 
-  def self.extract(file_path)
-    no_ext_filename = file_path.split('.')[0..-1][0]
-    #capture stderr because ffmpeg expects an output param and will error out
-    puts "Gathering information about the downloaded file."
-    file_info = Open3.popen3("ffmpeg -i #{file_path}") {|stdin, stdout, stderr, wait_thr| stderr.read }
-    puts "Done gathering information about the downloaded file."
+    def self.extract(file_path)
+      no_ext_filename = file_path.split('.')[0..-1][0]
+      #capture stderr because ffmpeg expects an output param and will error out
+      puts "Gathering information about the downloaded file."
+      file_info = Open3.popen3("ffmpeg -i #{file_path}") {|stdin, stdout, stderr, wait_thr| stderr.read }
+      puts "Done gathering information about the downloaded file."
 
-    if !file_info.to_s.empty?
-      audio_format_matches = file_info.match(/Audio: (\w*)/)
-      if audio_format_matches
-        audio_format = audio_format_matches[1]
-        puts "detected audio format: #{audio_format}"
+      if !file_info.to_s.empty?
+        audio_format_matches = file_info.match(/Audio: (\w*)/)
+        if audio_format_matches
+          audio_format = audio_format_matches[1]
+          puts "detected audio format: #{audio_format}"
+        else
+          raise "ERROR: Couldn't find any audio:\n#{file_info.inspect}"
+        end
+        
+        extension_mapper = {
+        'aac' => 'm4a',
+        'mp3' => 'mp3',
+        'vorbis' => 'ogg'
+        }
+
+        if extension_mapper.key?(audio_format)
+          output_extension = extension_mapper[audio_format]
+        else
+          #lame fallback
+          puts "Unknown audio format: #{audio_format}, using name as extension: '.#{audio_format}'."
+          output_extension = audio_format
+        end
+        output_filename = "#{no_ext_filename}.#{output_extension}"
+        if File.exist?(output_filename)
+          puts "Audio file seems to exist already, removing it before extraction."
+          File.delete(output_filename)
+        end
+        Open3.popen3("ffmpeg -i #{file_path} -vn -acodec copy #{output_filename}") { |stdin, stdout, stderr, wait_thr| stdout.read }
+        puts "Done extracting audio to #{output_filename}"
       else
-        raise "ERROR: Couldn't find any audio:\n#{file_info.inspect}"
+        raise "ERROR: Error while checking audio track of #{file_path}"
       end
-      
-      extension_mapper = {
-      'aac' => 'm4a',
-      'mp3' => 'mp3',
-      'vorbis' => 'ogg'
-      }
-
-      if extension_mapper.key?(audio_format)
-        output_extension = extension_mapper[audio_format]
-      else
-        #lame fallback
-        puts "Unknown audio format: #{audio_format}, using name as extension: '.#{audio_format}'."
-        output_extension = audio_format
-      end
-      output_filename = "#{no_ext_filename}.#{output_extension}"
-      if File.exist?(output_filename)
-        puts "Audio file seems to exist already, removing it before extraction."
-        File.delete(output_filename)
-      end
-      Open3.popen3("ffmpeg -i #{file_path} -vn -acodec copy #{output_filename}") { |stdin, stdout, stderr, wait_thr| stdout.read }
-      puts "Done extracting audio to #{output_filename}"
-    else
-      raise "ERROR: Error while checking audio track of #{file_path}"
     end
   end
+
 end
+

--- a/helper/download-helper.rb
+++ b/helper/download-helper.rb
@@ -1,82 +1,86 @@
-class DownloadHelper
+module ViddlRb
 
-  #usually not called directly
-  def self.fetch_file(uri)
-    begin
-      require "progressbar" #http://github.com/nex3/ruby-progressbar
-    rescue LoadError
-      puts "ERROR: You don't seem to have curl or wget on your system. In this case you'll need to install the 'progressbar' gem."
-      exit
-    end
-    progress_bar = nil 
-    open(uri, :proxy => nil,
-      :content_length_proc => lambda { |length|
-        if length && 0 < length
-          progress_bar = ProgressBar.new(uri.to_s, length)
-          progress_bar.file_transfer_mode   #to show download speed and file size
-        end 
-      },
-      :progress_proc => lambda { |progress|
-        progress_bar.set(progress) if progress_bar
-      }) {|file| return file.read}        
-  end
-  
-  #simple helper that will save a file from the web and save it with a progress bar
-  def self.save_file(file_uri, file_name, save_dir = ".", amount_of_retries = 6)
-    trap("SIGINT") { puts "goodbye"; exit }
-
-    file_path = File.absolute_path(File.join(save_dir, file_name))
-    #Some providers seem to flake out every now end then
-    amount_of_retries.times do |i|
-      if os_has?("wget")
-        puts "using wget"
-        `wget \"#{file_uri}\" -O #{file_path.inspect}`
-      elsif os_has?("curl")
-        puts "using curl"
-        #require "pry"; binding.pry; exit
-        #-L means: follow redirects, We set an agent because Vimeo seems to want one
-        `curl -A 'Wget/1.8.1' --retry 10 --retry-delay 5 --retry-max-time 4  -L \"#{file_uri}\" -o #{file_path.inspect}`
-      else
-       puts "using net/http"
-        open(file_path, 'wb') { |file|          
-          file.write(fetch_file(file_uri)); puts
-        }
-      end  
-      #we were successful, we're outta here
-      if $? == 0
-        break
-      else
-        puts "Download seems to have failed (retrying, attempt #{i+1}/#{amount_of_retries})"
-        sleep 2
+  class DownloadHelper
+    #usually not called directly
+    def self.fetch_file(uri)
+      begin
+        require "progressbar" #http://github.com/nex3/ruby-progressbar
+      rescue LoadError
+        puts "ERROR: You don't seem to have curl or wget on your system. In this case you'll need to install the 'progressbar' gem."
+        exit
       end
-    end    
-    $? == 0
-  end
+      progress_bar = nil 
+      open(uri, :proxy => nil,
+        :content_length_proc => lambda { |length|
+          if length && 0 < length
+            progress_bar = ProgressBar.new(uri.to_s, length)
+            progress_bar.file_transfer_mode   #to show download speed and file size
+          end 
+        },
+        :progress_proc => lambda { |progress|
+          progress_bar.set(progress) if progress_bar
+        }) {|file| return file.read}        
+    end
+    
+    #simple helper that will save a file from the web and save it with a progress bar
+    def self.save_file(file_uri, file_name, save_dir = ".", amount_of_retries = 6)
+      trap("SIGINT") { puts "goodbye"; exit }
 
-  #checks to see whether the os has a certain utility like wget or curl
-  #`` returns the standard output of the process
-  #system returns the exit code of the process
-  def self.os_has?(utility)
-    windows = ENV['OS'] =~ /windows/i
+      file_path = File.absolute_path(File.join(save_dir, file_name))
+      #Some providers seem to flake out every now end then
+      amount_of_retries.times do |i|
+        if os_has?("wget")
+          puts "using wget"
+          `wget \"#{file_uri}\" -O #{file_path.inspect}`
+        elsif os_has?("curl")
+          puts "using curl"
+          #require "pry"; binding.pry; exit
+          #-L means: follow redirects, We set an agent because Vimeo seems to want one
+          `curl -A 'Wget/1.8.1' --retry 10 --retry-delay 5 --retry-max-time 4  -L \"#{file_uri}\" -o #{file_path.inspect}`
+        else
+         puts "using net/http"
+          open(file_path, 'wb') { |file|          
+            file.write(fetch_file(file_uri)); puts
+          }
+        end  
+        #we were successful, we're outta here
+        if $? == 0
+          break
+        else
+          puts "Download seems to have failed (retrying, attempt #{i+1}/#{amount_of_retries})"
+          sleep 2
+        end
+      end    
+      $? == 0
+    end
 
-    unless windows # if os is not Windows
-      `which #{utility}`.include?(utility)
-    else
-      if has_where?
-        system("where /q #{utility}")   #/q is the quiet mode flag
+    #checks to see whether the os has a certain utility like wget or curl
+    #`` returns the standard output of the process
+    #system returns the exit code of the process
+    def self.os_has?(utility)
+      windows = ENV['OS'] =~ /windows/i
+
+      unless windows # if os is not Windows
+        `which #{utility}`.include?(utility)
       else
-        begin   #as a fallback we just run the utility itself
-          system(utility)
-        rescue Errno::ENOENT
-          false
+        if has_where?
+          system("where /q #{utility}")   #/q is the quiet mode flag
+        else
+          begin   #as a fallback we just run the utility itself
+            system(utility)
+          rescue Errno::ENOENT
+            false
+          end
         end
       end
     end
+
+    #checks if Windows has the where utility (Server 2003 and later)
+    #system only return nil if the command is not found
+    def self.has_where?
+      !system("where /q where").nil?
+    end
   end
 
-  #checks if Windows has the where utility (Server 2003 and later)
-  #system only return nil if the command is not found
-  def self.has_where?
-    !system("where /q where").nil?
-  end
 end
+

--- a/helper/plugin-helper.rb
+++ b/helper/plugin-helper.rb
@@ -1,55 +1,60 @@
-class PluginBase
+module ViddlRb
 
-  #this exception is raised by the plugins when it was not 
-  #possible to donwload the video for some reason.
-  class CouldNotDownloadVideoError < StandardError; end
+  class PluginBase
 
-  #some static stuff
-  class << self
-    attr_accessor :io
-    attr_reader   :registered_plugins
-  end
+    #this exception is raised by the plugins when it was not 
+    #possible to donwload the video for some reason.
+    class CouldNotDownloadVideoError < StandardError; end
 
-  #all calls to #puts, #print and #p from any plugin instance will be redirected to this object 
-  @io = $stdout
-  @registered_plugins = []
-
-  #if you inherit from this class, the child gets added to the "registered plugins" array
-  def self.inherited(child)
-    PluginBase.registered_plugins << child
-  end
-
-  #takes a string a returns a new string that is file name safe
-  #deletes \"' and replaces anything else that is not a digit or letter with _
-  def self.make_filename_safe(string)
-    string.delete("\"'").gsub(/[^\d\w]/, '_')
-  end
-
-  #the following methods redirects the Kernel printing methods (except #p) to the
-  #PluginBase IO object. this is because sometimes we want plugins to
-  #write to something else than $stdout
-
-  def self.puts(*objects)
-    PluginBase.io.puts(*objects)
-    nil
-  end
-
-  def self.print(*objects)
-    PluginBase.io.print(*objects)
-    nil
-  end
-
-  def self.putc(int)
-    PluginBase.io.putc(int)
-    nil
-  end
-
-  def self.printf(string, *objects)
-    if string.is_a?(IO) || string.is_a?(StringIO)
-      super(string, *objects)  # so we don't redirect the printf that prints to a separate IO object
-    else
-      PluginBase.io.printf(string, *objects)
+    #some static stuff
+    class << self
+      attr_accessor :io
+      attr_reader   :registered_plugins
     end
-    nil
+
+    #all calls to #puts, #print and #p from any plugin instance will be redirected to this object 
+    @io = $stdout
+    @registered_plugins = []
+
+    #if you inherit from this class, the child gets added to the "registered plugins" array
+    def self.inherited(child)
+      PluginBase.registered_plugins << child
+    end
+
+    #takes a string a returns a new string that is file name safe
+    #deletes \"' and replaces anything else that is not a digit or letter with _
+    def self.make_filename_safe(string)
+      string.delete("\"'").gsub(/[^\d\w]/, '_')
+    end
+
+    #the following methods redirects the Kernel printing methods (except #p) to the
+    #PluginBase IO object. this is because sometimes we want plugins to
+    #write to something else than $stdout
+
+    def self.puts(*objects)
+      PluginBase.io.puts(*objects)
+      nil
+    end
+
+    def self.print(*objects)
+      PluginBase.io.print(*objects)
+      nil
+    end
+
+    def self.putc(int)
+      PluginBase.io.putc(int)
+      nil
+    end
+
+    def self.printf(string, *objects)
+      if string.is_a?(IO) || string.is_a?(StringIO)
+        super(string, *objects)  # so we don't redirect the printf that prints to a separate IO object
+      else
+        PluginBase.io.printf(string, *objects)
+      end
+      nil
+    end
   end
+
 end
+

--- a/helper/utility-helper.rb
+++ b/helper/utility-helper.rb
@@ -1,10 +1,16 @@
 # This class contains utility methods that are used by both the bin utility and the library.
 
-class UtilityHelper
-  #loads all plugins in the plugin directory.
-  def self.load_plugins
-    Dir[File.join(File.dirname(__FILE__),"../plugins/*.rb")].each do |plugin|
-      require plugin
+module ViddlRb
+
+  class UtilityHelper
+    #loads all plugins in the plugin directory.
+    #the plugin classes are dynamically added to the ViddlRb module.
+    def self.load_plugins
+      Dir[File.join(File.dirname(__FILE__), "../plugins/*.rb")].each do |plugin|
+        ViddlRb.class_eval(File.read(plugin))
+      end
     end
   end
+
 end
+

--- a/lib/viddl-rb.rb
+++ b/lib/viddl-rb.rb
@@ -13,7 +13,7 @@ require "plugin-helper.rb"
 require "utility-helper.rb"
 
 #load all plugins
-UtilityHelper.load_plugins
+ViddlRb::UtilityHelper.load_plugins
 
 module ViddlRb
   class PluginError < StandardError; end


### PR DESCRIPTION
So that if someone uses the library there's a much smaller risk of name conflicts. I wrapped all the classes that are used by the library in the ViddlRb module.

The library uses all the plugins too of course, but I opted to do a class_eval in the ViddlRb module (see the UtilityHelper file) so you don't need to explicitly wrap the plugin classes in ViddlRb module. I think this reduces code noise a bit, but let me know what you think about it. 
