### PR TITLE
Join the save_dir to the file_path while using ffmpeg

### DIFF
--- a/helper/audio-helper.rb
+++ b/helper/audio-helper.rb
@@ -7,7 +7,7 @@ module ViddlRb
       no_ext_filename = file_path.split('.')[0..-1][0]
       #capture stderr because ffmpeg expects an output param and will error out
       puts "Gathering information about the downloaded file."
-      file_info = Open3.popen3("ffmpeg -i #{file_path}") {|stdin, stdout, stderr, wait_thr| stderr.read }
+      file_info = Open3.popen3("ffmpeg -i #{File.join(save_dir, file_path)}") {|stdin, stdout, stderr, wait_thr| stderr.read }
       puts "Done gathering information about the downloaded file."
 
       if !file_info.to_s.empty?
@@ -18,11 +18,11 @@ module ViddlRb
         else
           raise "ERROR: Couldn't find any audio:\n#{file_info.inspect}"
         end
-        
+
         extension_mapper = {
-        'aac' => 'm4a',
-        'mp3' => 'mp3',
-        'vorbis' => 'ogg'
+          'aac' => 'm4a',
+          'mp3' => 'mp3',
+          'vorbis' => 'ogg'
         }
 
         if extension_mapper.key?(audio_format)


### PR DESCRIPTION
So I'm running this command locally:

`farleyknight@farleyknight-desktop:~/dev/ruby/rb2k/viddl-rb$ ruby bin/viddl-rb http://www.youtube.com/view_play_list?p=RD020bXB5zyF3TI --extract-audio --save-dir /home/farleyknight/Downloads/trap_youtube_mp3z/`

After a bit of processing, I get:

```
Download for Waka_Flocka___Cant_Do_Gold__Official_Music_Video_.mp4 successful.
Gathering information about the downloaded file.
Done gathering information about the downloaded file.
Error: ERROR: Couldn't find any audio:
"ffmpeg version 0.8.6-4:0.8.6-0ubuntu0.12.04.1, Copyright (c) 2000-2013 the Libav developers\n  built on Apr  2 2013 17:02:36 with gcc 4.6.3\n*** THIS PROGRAM IS DEPRECATED ***\nThis program is only provided for compatibility and will be removed in a future release. Please use avconv instead.\nWaka_Flocka___Cant_Do_Gold__Official_Music_Video_.mp4: No such file or directory\n"
```

So it seems that it's trying to find the file in the local directory, when it's actually saved in a separate directory. This pull request should fix that.
