### PR TITLE
Allow videos to be skipped if they cannot be downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Download a video:
 Viddl-rb supports the following command line options:
 ```
 -e, --extract-audio              Save video audio to file
--k  --skip-failed                Skip failed downloads
+-a, --abort-on-failure           Abort download queue if one of the videos fail to download
 -u, --url-only                   Prints url without downloading
 -t, --title-only                 Prints title without downloading
 -f, --filter REGEX               Filters a video playlist according to the regex (Youtube only right now)

--- a/bin/helper/downloader.rb
+++ b/bin/helper/downloader.rb
@@ -10,10 +10,10 @@ class Downloader
 
       result = ViddlRb::DownloadHelper.save_file(url, name, :save_dir => params[:save_dir], :tool => params[:tool])
       unless result
-        if params[:skip_failed]
-          puts "Download for #{name} failed. Moving onto next file."
-        else
+        if params[:abort_on_failure]
           raise DownloadFailedError, "Download for #{name} failed."
+        else
+          puts "Download for #{name} failed. Moving onto next file."
         end
       else
         puts "Download for #{name} successful."

--- a/bin/helper/parameter-parser.rb
+++ b/bin/helper/parameter-parser.rb
@@ -22,7 +22,7 @@ class ParameterParser
     # Default option values are set here
     options = {
       :extract_audio    => false,
-      :skip_failed      => false,
+      :abort_on_failure => false,
       :url_only         => false,
       :title_only       => false,
       :playlist_filter  => nil,
@@ -42,8 +42,8 @@ class ParameterParser
         end
       end
 
-      opts.on("-k", "--skip-failed", "Skip failed downloads") do
-        options[:skip_failed] = true
+      opts.on("-a", "--abort-on-failure", "Abort download queue if one of the videos fail to download") do
+        options[:abort_on_failure] = true
       end
 
       opts.on("-u", "--url-only", "Prints url without downloading") do


### PR DESCRIPTION
This is a new feature that allows users to skip failed downloads, when downloading a playlist.
