### PR TITLE
YouTube plugin refactoring

### DIFF
--- a/plugins/youtube.rb
+++ b/plugins/youtube.rb
@@ -71,6 +71,9 @@ class Youtube < PluginBase
       grab_url_embeddable(url) || grab_url_non_embeddable(url)
     end
 
+    # VEVO video: http://www.youtube.com/watch?v=A_J7kEhY9sM
+    # Non-VEVO video: http://www.youtube.com/watch?v=WkkC9cK8Hz0
+
     def grab_url_embeddable(url)
       video_info   = get_video_info(url)
       video_params = extract_video_parameters(video_info)
@@ -108,13 +111,13 @@ class Youtube < PluginBase
     end
 
     def extract_video_parameters(video_info)
-      decoded = url_decode(video_info)
+      video_params = CGI.parse(url_decode(video_info))
 
       {
-        :title      => decoded[/title=(.+?)(?:&|$)/, 1],
-        :length_sec => decoded[/length_seconds=(.+?)(?:&|$)/, 1],
-        :author     => decoded[/author=(.+?)(?:&|$)/, 1],
-        :embeddable => !decoded.include?("status=fail")
+        :title      => video_params["title"].first,
+        :length_sec => video_params["length_seconds"].first,
+        :author     => video_params["author"].first,
+        :embeddable => (video_params["status"].first != "fail")
       }
     end
 


### PR DESCRIPTION
I'm in the process of refactoring the YouTube plugin so VEVO videos processing appropriately. This is the video I've been using as an example (NOTE: it should fail with HTTP code 403):

http://www.youtube.com/watch?v=A_J7kEhY9sM

I've been studying the code on `youtube-dl` (based on Python). The reason for the failure is related to decryption of the signature, as well as some heavy parameter mangling.

This PR is just to get some refactors into the core, so I can continue research here and there, when I get the urge to try and download more videos. All the tests should pass. If you want to add more tests, I'm game. Just give me a mid-to-high level description of what kinds of tests you'd like to see added, and I can make sure they show up here before asking for a merge.
