### PR TITLE
Add new cipher

### DIFF
--- a/plugins/youtube/ciphers.yml
+++ b/plugins/youtube/ciphers.yml
@@ -93,4 +93,5 @@ en_US-vflbT9-GA: w51 w15 s1 w22 s1 w41 r w43 r
 en_US-vflAYBrl7: s2 r w39 w43
 en_US-vflS1POwl: w48 s2 r s1 w4 w35
 en_US-vflLMtkhg: w30 r w30 w39
+en_US-vflgd5txb: w26 s1 w15 w3 w62 w54 w22
 en_US-vflbJnZqE: w26 s1 w15 w3 w62 w54 w22


### PR DESCRIPTION
While porting the decipher algorithm to https://github.com/flagbug/YoutubeExtractor, I found the a new cipher `en_US-vflgd5txb`. running guesser.rb, it spit out the correct operations
