### PR TITLE
Set wget to resume download

### DIFF
--- a/helper/download-helper.rb
+++ b/helper/download-helper.rb
@@ -27,7 +27,7 @@ module ViddlRb
       end,
 
       Tool.new(:wget) do |url, path|
-        "wget #{url.inspect} -O #{path.inspect}"
+        "wget -c #{url.inspect} -O #{path.inspect}"
       end,
 
       Tool.new(:curl) do |url, path|


### PR DESCRIPTION
This change allows wget to resume a download if it has already been partially downloaded.
