### PR TITLE
Improvement on Soundcloud plugin + new Bandcamp plugin

### DIFF
--- a/plugins/bandcamp.rb
+++ b/plugins/bandcamp.rb
@@ -14,20 +14,18 @@ class Bandcamp < PluginBase
     # locate the js object with all the tracks data
     url_and_files = []
     doc           = Nokogiri::HTML(open(get_http_url(url)))
-    js            = doc.at("script:eq(9)").text
-    match         = js[/trackinfo \: (\[\{.*\"\}\]),/, 1]
-    
+    js            = doc.at("script:contains('var TralbumData')").text
+    match         = js[/trackinfo.*(\[.*\])/,1]
+
     # parse the js object
     JSON.parse(match).each do |track_data|
       track_url   = ''
 
       # hopefully the last is the best
-      track_data['file'].each do |key, file|
-        track_url = file
-      end
+      track_url  = track_data["file"].values.last
       
       # create a good mp3 name
-      track_name  = transliterate(track_data['title']) + '.mp3'
+      track_name  = self.make_filename_safe(track_data['title']) + '.mp3'
       
       # add to the response
       url_and_files << {url: track_url, name: track_name}
@@ -35,29 +33,7 @@ class Bandcamp < PluginBase
 
     url_and_files
   end
-
-
-  def self.transliterate(str)
-    # Based on permalink_fu by Rick Olsen
-
-    # Downcase string
-    str.downcase!
-
-    # Remove apostrophes so isn't changes to isnt
-    str.gsub!(/'/, '')
-
-    # Replace any non-letter or non-number character with a space
-    str.gsub!(/[^A-Za-z0-9]+/, ' ')
-
-    # Remove spaces from beginning and end of string
-    str.strip!
-
-    # Replace groups of spaces with single hyphen
-    str.gsub!(/\ +/, '-')
-
-    str
-  end
-
+  
   def self.get_http_url(url)
     url.sub(/https?:\/\//, "http:\/\/")
   end

--- a/plugins/soundcloud.rb
+++ b/plugins/soundcloud.rb
@@ -1,3 +1,4 @@
+require 'nokogiri'
 require 'open-uri'
 require 'json'
 
@@ -20,36 +21,13 @@ class Soundcloud < PluginBase
       track_data  = JSON.parse(match[1])
       
       file_url    = track_data['streamUrl']
-      file_name   = transliterate(track_data['title'].to_s) + '.mp3'
+      file_name   = self.make_filename_safe(track_data['title'].to_s) + '.mp3'
 
       url_and_files << {url: file_url, name: file_name}
     end
 
     url_and_files
   end
-
-
-  def self.transliterate(str)
-    # Based on permalink_fu by Rick Olsen
-
-    # Downcase string
-    str.downcase!
-
-    # Remove apostrophes so isn't changes to isnt
-    str.gsub!(/'/, '')
-
-    # Replace any non-letter or non-number character with a space
-    str.gsub!(/[^A-Za-z0-9]+/, ' ')
-
-    # Remove spaces from beginning and end of string
-    str.strip!
-
-    # Replace groups of spaces with single hyphen
-    str.gsub!(/\ +/, '-')
-
-    str
-  end
-
 
   def self.get_http_url(url)
     url.sub(/https?:\/\//, "http:\/\/")

--- a/spec/integration/url_extraction_spec.rb
+++ b/spec/integration/url_extraction_spec.rb
@@ -6,6 +6,7 @@ class URLExtractionTest < Minitest::Test
   def setup
   end
 
+
   def http_code_grabber(url, options = {})
     user_agent = options[:user_agent] || "Wget/1.8.1"
     http_method = options[:method] || :head
@@ -18,7 +19,7 @@ class URLExtractionTest < Minitest::Test
     http_code = result.scan(/HTTP\/\d\.\d\s+(\d+)/).flatten.last
     http_code.to_i rescue 0  # if no match, return 0
   end
-    
+
   def test_youtube
     result = `ruby bin/viddl-rb http://www.youtube.com/watch?v=CFw6s0TN3hY --url-only`
     assert_equal $?, 0
@@ -87,6 +88,12 @@ class URLExtractionTest < Minitest::Test
     result = `ruby bin/viddl-rb http://blip.tv/red-vs-blue/red-vs-blue-episode-11-5526271 --url-only`
     assert_equal $?, 0
     can_download_test(result)
+  end
+
+  def test_bandcamp
+    result = `ruby bin/viddl-rb http://fontarabie.bandcamp.com/track/cosmogonie --url-only`
+    assert_equal $?, 0
+    can_download_test(result) { |url_output| http_code_grabber(CGI::unescape(url_output), {:method => :get}) }
   end
 
   # NOTE: The Metacafe tests are skipped because plugin is currently broken.


### PR DESCRIPTION
The soundcloud plugin only gave support for track pages and would crash on the user's main page. Now the plugin will return an array of urls.

Also added plugin to bandcamp pages.
