### PR TITLE
fix vimeo video id detection

### DIFF
--- a/plugins/vimeo.rb
+++ b/plugins/vimeo.rb
@@ -6,8 +6,8 @@ class Vimeo < PluginBase
   end
   
   def self.get_urls_and_filenames(url, options = {})
-    #the vimeo ID consists of 7 decimal numbers in the URL
-    vimeo_id = url[/\d{7,8}/]
+    #the vimeo ID consists of 7 decimal numbers or more in the URL
+    vimeo_id = url[/\d{7,}/]
 
     video_url = "http://player.vimeo.com/video/#{vimeo_id}"
     video_page = open(video_url).read


### PR DESCRIPTION
new video ids are now longer than 8 digits
