### PR TITLE
Add ability to download multiple urls

### DIFF
--- a/bin/helper/driver.rb
+++ b/bin/helper/driver.rb
@@ -5,21 +5,31 @@
 class Driver
 
   def initialize(param_hash)
+    @urls = param_hash[:urls]
+    param_hash.delete :urls
     @params = param_hash
     @downloader = Downloader.new
   end
 
   #starts the downloading process or print just the urls or names.
   def start
-    queue = get_download_queue
+    @urls.each do |url|
+      @params[:url] = url
+      puts "\nAnalyzing URL: #{url}"
+      begin
+        queue = get_download_queue
 
-    if @params[:url_only]
-      queue.each { |url_name| puts url_name[:url] }
-    elsif @params[:title_only]
-      queue.each { |url_name| puts url_name[:name] }
-    else
-      @downloader.download(queue, @params)
-    end
+        if @params[:url_only]
+          queue.each { |url_name| puts url_name[:url] }
+        elsif @params[:title_only]
+          queue.each { |url_name| puts url_name[:name] }
+        else
+          @downloader.download(queue, @params)
+        end
+      rescue => e
+        puts e.message
+      end
+   end
   end
 
   private

--- a/bin/helper/parameter-parser.rb
+++ b/bin/helper/parameter-parser.rb
@@ -8,7 +8,7 @@ class ParameterParser
   DEFAULT_SAVE_DIR = "."
 
   #returns a hash with the parameters in it:
-  # :url              => the video url
+  # :urls             => array of the video urls
   # :extract_audio    => should attempt to extract audio? (true/false)
   # :skip_failed      => should skip failed downloads? (true/false)
   # :url_only         => do not download, only print the urls to stdout
@@ -98,13 +98,8 @@ class ParameterParser
     optparse.parse!(args)
     # exit if no video url
     print_help_and_exit(optparse) if args.empty?
-    # the url is the only element left
-    url = args.first
-    # Seems like some users like to pass non protocol prefixed URIs
-    url = "http://#{url}" unless url.start_with?('http')
-    # raise exception if invalid url
-    validate_url!(url)
-    options[:url] = url
+    # remaining elements in args will be urls
+    options[:urls] = validate_urls args
     options
   end
 
@@ -113,11 +108,8 @@ class ParameterParser
     exit(0)
   end
 
-  def self.validate_url!(url)
-    unless url =~ /^http/
-      raise OptionParser::InvalidArgument.new(
-          "please include 'http' with your URL e.g. http://www.youtube.com/watch?v=QH2-TGUlwu4")
-    end
+  def self.validate_urls(urls)
+    urls.map {|url| url.start_with?("http") ? url : "http://#{url}"}
   end
 
   def self.validate_quality_options!(width, height, extension, quality)

--- a/bin/viddl-rb
+++ b/bin/viddl-rb
@@ -26,7 +26,6 @@ begin
   puts "Plugins loaded: #{ViddlRb::PluginBase.registered_plugins.inspect}"
 
   puts "Will try to extract audio: #{params[:extract_audio] == true}."
-  puts "Analyzing URL: #{params[:url]}"
 
   driver = Driver.new(params)   
   driver.start                  # starts the download process


### PR DESCRIPTION
This commit also prepends "http://" to urls that don't start with it and therefore removes the validate_url! method.

The changes are pretty simple. Urls are stored in an array and processed one by one. Errors are rescued and printed before proceeding to the next url.